### PR TITLE
Define property rating functions

### DIFF
--- a/supabase.types.ts
+++ b/supabase.types.ts
@@ -292,7 +292,20 @@ export interface Database {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_average_property_rating: {
+        Args: {
+          property_id: string
+        }
+        Returns: number
+      }
+      get_properties_with_ratings: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          property_id: string
+          address: string
+          average_rating: number
+        }[]
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20240215131101_define_property_rating_functions.sql
+++ b/supabase/migrations/20240215131101_define_property_rating_functions.sql
@@ -1,0 +1,25 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_average_property_rating(property_id uuid)
+ RETURNS numeric
+ LANGUAGE sql
+ STABLE
+AS $function$
+  SELECT AVG(property_rating)
+    FROM reviews
+    WHERE reviews.property_id = get_average_property_rating.property_id;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_properties_with_ratings()
+ RETURNS TABLE(property_id uuid, address text, average_rating numeric)
+ LANGUAGE plpgsql
+AS $function$
+#variable_conflict use_column 
+BEGIN
+  RETURN QUERY select id as property_id, address, get_average_property_rating(id) as average_rating
+  from properties;
+END; $function$
+;
+
+


### PR DESCRIPTION
Defined two postgres functions:

### get_average_property_rating

- Given a property id, returns the average property_rating on reviews for that property
- Used by the other function
- Separated to allow direct fetching of average rating when you only care about one property (e.g. on its own page)

### get_properties_with_ratings

- Returns a table of all properties with an additional column for the average rating
- Intended for use in cases like the property search page where ratings for multiple properties are wanted
- Allows sorting by rating
- Can be expanded to include other computed data e.g. current landlord rating
