### PR TITLE
Review Detail Component

### DIFF
--- a/components/ReviewDetails.tsx
+++ b/components/ReviewDetails.tsx
@@ -78,10 +78,10 @@ export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
                         <StarRating rating={propertyRating} />
                     </div>
 
-                    {/* <div className="flex flex-col"> */}
-                        {/* <p className="text-lg font-semibold">Landlord:</p> */}
-                        {/* <StarRating rating={landlordRating} /> */}
-                    {/* </div> */}
+                    <div className="flex flex-col">
+                        <p className="text-lg font-semibold">Landlord:</p>
+                        <StarRating rating={landlordRating} />
+                    </div>
                 {/* </div> */}
 
                 {/* <p className="text-lg font-semibold">Review:</p> */}

--- a/components/ReviewDetails.tsx
+++ b/components/ReviewDetails.tsx
@@ -84,8 +84,8 @@ export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
                     </div>
                 </div>
 
-                {/* <p className="text-lg font-semibold">Review:</p> */}
-                {/* <p className="border rounded-md h-fit min-h-[5rem] bg-gray-100/10 py-1 px-2">{reviewMessage}</p> */}
+                <p className="text-lg font-semibold">Review:</p>
+                <p className="border rounded-md h-fit min-h-[5rem] bg-gray-100/10 py-1 px-2">{reviewMessage}</p>
                 <p className="ml-auto text-gray-300">{reviewDate.toLocaleDateString()}</p>
             </div>
         </MaybeLink>

--- a/components/ReviewDetails.tsx
+++ b/components/ReviewDetails.tsx
@@ -72,7 +72,7 @@ export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
             {/* <p>Reviewer ID: {reviewerId}</p> */}
             <div className="flex flex-col w-full sm:w-4/5 gap-2">
 
-                {/* <div className="flex flex-col sm:flex-row justify-around place-items-center"> */}
+                <div className="flex flex-col sm:flex-row justify-around place-items-center">
                     <div className="flex flex-col">
                         <p className="text-lg font-semibold">Property:</p>
                         <StarRating rating={propertyRating} />
@@ -82,7 +82,7 @@ export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
                         <p className="text-lg font-semibold">Landlord:</p>
                         <StarRating rating={landlordRating} />
                     </div>
-                {/* </div> */}
+                </div>
 
                 {/* <p className="text-lg font-semibold">Review:</p> */}
                 {/* <p className="border rounded-md h-fit min-h-[5rem] bg-gray-100/10 py-1 px-2">{reviewMessage}</p> */}

--- a/components/ReviewDetails.tsx
+++ b/components/ReviewDetails.tsx
@@ -1,0 +1,144 @@
+'use Server'
+
+import { createClient } from "@/utils/supabase/server"
+import { cookies } from "next/headers"
+import Link from "next/link"
+
+import { StarIcon } from '@heroicons/react/24/solid'
+
+interface ReviewDetailsProps {
+    reviewId: string
+    link?: boolean
+}
+export const ReviewDetails: React.FC<ReviewDetailsProps> = async ({
+    reviewId,
+    link = false
+}) => {
+    const cookieStore = cookies()
+    const supabase = createClient(cookieStore)
+
+    const { data, error } = await supabase
+        .from('reviews')
+        .select('*')
+        .eq('review_id', reviewId)
+        .single()
+
+    if (error || !data) {
+        console.error(error)
+        return null
+    }
+
+    return <ReviewDetailsLayout
+        reviewId={reviewId}
+        reviewerId={data.review_id}
+        reviewDate={new Date(data.review_date)}
+        landlordRating={data.landlord_rating}
+        propertyRating={data.property_rating}
+        reviewMessage={data.review_body}
+        link={link}
+    />
+}
+
+interface ReviewDetails {
+    reviewId: string
+    reviewerId: string
+    reviewDate: Date
+    landlordRating: number
+    propertyRating: number
+    reviewMessage: string
+}
+
+interface ReviewDetailsLayoutProps extends ReviewDetails {
+    link?: boolean
+}
+// export seperately to allow pages that already have the data to use the standardised layout
+export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
+    reviewId,
+    reviewerId,
+    reviewDate,
+    landlordRating,
+    propertyRating,
+    reviewMessage,
+    link = false
+}) => {
+    return (
+        <MaybeLink
+            conditionMet={link}
+            link={`/review/${reviewId}`}
+            className="flex flex-1 flex-col px-8 py-2 sm:px-4 border rounded-lg h-fit w-full max-w-prose justify-center place-items-center"
+        >
+            {/* <h1>Review Details</h1> */}
+            {/* <p>Review ID: {reviewId}</p> */}
+            {/* <p>Reviewer ID: {reviewerId}</p> */}
+            <div className="flex flex-col w-full sm:w-4/5 gap-2">
+
+                {/* <div className="flex flex-col sm:flex-row justify-around place-items-center"> */}
+                    {/* <div className="flex flex-col"> */}
+                        {/* <p className="text-lg font-semibold">Property:</p> */}
+                        {/* <StarRating rating={propertyRating} /> */}
+
+                    {/* <div className="flex flex-col"> */}
+                        {/* <p className="text-lg font-semibold">Landlord:</p> */}
+                        {/* <StarRating rating={landlordRating} /> */}
+                    {/* </div> */}
+                {/* </div> */}
+
+                {/* <p className="text-lg font-semibold">Review:</p> */}
+                {/* <p className="border rounded-md h-fit min-h-[5rem] bg-gray-100/10 py-1 px-2">{reviewMessage}</p> */}
+                <p className="ml-auto text-gray-300">{reviewDate.toLocaleDateString()}</p>
+            </div>
+        </MaybeLink>
+    )
+}
+
+
+interface MaybeLinkProps {
+    conditionMet: boolean
+    link: string
+    children: React.ReactNode
+    className?: string
+}
+const MaybeLink: React.FC<MaybeLinkProps> = ({
+    conditionMet,
+    link,
+    children,
+    className
+}) => {
+    if (conditionMet) {
+        return (
+            <Link
+                href={link}
+                className={className}
+            >
+                {children}
+            </Link>
+        )
+    }
+    return (
+        <div className={className}>
+            {children}
+        </div>
+    )
+}
+
+interface StarRatingProps {
+    rating: number
+}
+export const StarRating: React.FC<StarRatingProps> = ({
+    rating
+}) => {
+    return (
+        <div className="flex">
+            {Array.from({ length: 5 }).map((_, i) => {
+                const starNumber = i + 1
+                const isFilled = starNumber <= rating
+                return (
+                    <StarIcon
+                        key={i}
+                        className={`h-10 w-10 ${isFilled ? 'text-yellow-300' : 'text-gray-400'}`}
+                    />
+                )
+            })}
+        </div>
+    )
+}

--- a/components/ReviewDetails.tsx
+++ b/components/ReviewDetails.tsx
@@ -73,9 +73,10 @@ export const ReviewDetailsLayout: React.FC<ReviewDetailsLayoutProps> = ({
             <div className="flex flex-col w-full sm:w-4/5 gap-2">
 
                 {/* <div className="flex flex-col sm:flex-row justify-around place-items-center"> */}
-                    {/* <div className="flex flex-col"> */}
-                        {/* <p className="text-lg font-semibold">Property:</p> */}
-                        {/* <StarRating rating={propertyRating} /> */}
+                    <div className="flex flex-col">
+                        <p className="text-lg font-semibold">Property:</p>
+                        <StarRating rating={propertyRating} />
+                    </div>
 
                     {/* <div className="flex flex-col"> */}
                         {/* <p className="text-lg font-semibold">Landlord:</p> */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "Rental_Review",
+  "name": "rental-review",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
+        "@heroicons/react": "^2.1.1",
         "@supabase/ssr": "latest",
         "@supabase/supabase-js": "latest",
         "autoprefixer": "10.4.15",
@@ -34,6 +35,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-JyyN9Lo66kirbCMuMMRPtJxtKJoIsXKS569ebHGGRKbl8s4CtUfLnyKJxteA+vIKySocO4s1SkTkGS4xtG/yEA==",
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@heroicons/react": "^2.1.1",
     "@supabase/ssr": "latest",
     "@supabase/supabase-js": "latest",
     "autoprefixer": "10.4.15",


### PR DESCRIPTION
Created a simple component to display the details of a single review

<img width="726" alt="Screenshot 2024-02-18 at 01 55 20" src="https://github.com/CM20254-Group-7/Rental_Review/assets/74842299/ac2ff009-02a1-4582-ac57-0d0ba001f706">

closes:

- RRS-69
- RRS-72
- RRS-71
- RRS-70
- RRS-68

Has an optional parameter to link to a dedicated review detail page (if we add one)

Stores the landlord and property ids in case we want to add the option to link to one while the component is in a different context

exports both:
- A function taking the review id and returning the component with the data for that id
- a function taking the review data and formatting it the same way
Use whichever one works best in the context of the data you already have when calling them