### PR TITLE
Dynamic users in tests

### DIFF
--- a/playwright-tests/helpers.ts
+++ b/playwright-tests/helpers.ts
@@ -2,11 +2,39 @@ import { Page, expect } from "@playwright/test";
 
 const apiBaseURL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 
+const userIds = [
+    'b1b284f9-2c24-4f2e-bd4e-9c7ab7fe88e3',
+    '44db487d-ace4-43c8-bd7c-38b32b0bc711',
+    'e155848a-f32b-4d7d-a8d2-4228a7989078',
+    '482afef6-1b2f-4ac2-a449-9bc318f55936',
+    '4dfc3778-a1f2-410d-ae3d-9c92a469db8d',
+    '470b631a-addd-4380-acf3-b476e136d5f6',
+    'a5ceb0f0-707e-47b8-9021-cf451fca19be',
+    'f48d6af6-5b3e-4834-ab9d-3e2d9af434b6',
+    '1c6ff33c-5efe-4b45-bd35-13783eebbee2',
+    '5b3bb17f-33fe-40dd-a387-285e70812f0b',
+]
+
+const userLabels = [
+    'User 1',
+    'User 2',
+    'User 3',
+    'User 4',
+    'User 5',
+    'User 6',
+    'User 7',
+    'User 8',
+    'User 9',
+    'User 10',
+]
+
 export const users = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(i => {
     return {
         file: `playwright/.auth/user${i}.json`,
         email: `user.${i}@example.com`,
         password: `User.${i}.Password`,
+        id: userIds[i - 1],
+        label: userLabels[i - 1],
     }
 });
 

--- a/playwright-tests/landlord-page-tests.spec.ts
+++ b/playwright-tests/landlord-page-tests.spec.ts
@@ -3,8 +3,8 @@ import { users } from './helpers';
 
 // This test uses 3 users
 // for each it will check what is displayed on the landlord's profile page
-const firstUser  = users[0]; // Landlord with no properties
-const secondUser = users[1]; // Landlord with 2 properties
+const firstUser  = users[1]; // Landlord with no properties
+const secondUser = users[0]; // Landlord with 2 properties
 const thirdUser  = users[2]; // Not a landlord
 
 test.describe('Landlord Profile Page Tests', () => {

--- a/playwright-tests/landlord-page-tests.spec.ts
+++ b/playwright-tests/landlord-page-tests.spec.ts
@@ -1,33 +1,42 @@
 import { test, expect } from '@playwright/test';
+import { users } from './helpers';
 
-test('Landlord with no properties test', async ({ page }) => {
-  await page.goto('http://localhost:3000/profiles/44db487d-ace4-43c8-bd7c-38b32b0bc711');
-  await expect(page.getByRole('main')).toContainText('Test Name 2');
-  await expect(page.getByRole('main')).toContainText('display2@example.com');
-  await expect(page.getByRole('main')).toContainText('Cooler landlord');
-  await expect(page.getByRole('main')).toContainText('No properties');
-});
+// This test uses 3 users
+// for each it will check what is displayed on the landlord's profile page
+const firstUser  = users[0]; // Landlord with no properties
+const secondUser = users[1]; // Landlord with 2 properties
+const thirdUser  = users[2]; // Not a landlord
 
-test('Landlord with properties', async ({ page }) => {
-  await page.goto('http://localhost:3000/profiles/b1b284f9-2c24-4f2e-bd4e-9c7ab7fe88e3');
-  await expect(page.getByRole('main')).toContainText('Test Name 1');
-  await expect(page.getByRole('main')).toContainText('display1@example.com');
-  await expect(page.getByRole('main')).toContainText('Cool landlord');
-  await expect(page.getByRole('list')).toContainText('1 Test Road');
-  await expect(page.getByRole('list')).toContainText('2 Test Road');
-});
+test.describe('Landlord Profile Page Tests', () => {
+  test(`${firstUser.label} - No owned properties`,  async ({ page }) => {
+    await page.goto(`http://localhost:3000/profiles/${firstUser.id}`);
+    await expect(page.getByRole('main')).toContainText('Test Name 2');
+    await expect(page.getByRole('main')).toContainText('display2@example.com');
+    await expect(page.getByRole('main')).toContainText('Cooler landlord');
+    await expect(page.getByRole('main')).toContainText('No properties');
+  });
 
-test('Landlord does not exist: user with ID is not a landlord', async ({ page }) => {
-  await page.goto('http://localhost:3000/profile/e155848a-f32b-4d7d-a8d2-4228a7989078');
-  await expect(page.locator('h2')).toContainText('This page could not be found.');
-});
+  test(`${secondUser.label} - Two owned properties`, async ({ page }) => {
+    await page.goto(`http://localhost:3000/profiles/${secondUser.id}`);
+    await expect(page.getByRole('main')).toContainText('Test Name 1');
+    await expect(page.getByRole('main')).toContainText('display1@example.com');
+    await expect(page.getByRole('main')).toContainText('Cool landlord');
+    await expect(page.getByRole('list')).toContainText('1 Test Road');
+    await expect(page.getByRole('list')).toContainText('2 Test Road');
+  });
 
-test('Landlord does not exist: no user with ID', async ({ page }) => {
-  await page.goto('http://localhost:3000/profile/123');
-  await expect(page.locator('h2')).toContainText('This page could not be found.');
-});
+  test(`${thirdUser.label} - Not a landlord`, async ({ page }) => {
+    await page.goto(`http://localhost:3000/profiles/${thirdUser.id}`);
+    await expect(page.locator('h2')).toContainText('This page could not be found.');
+  });
 
-test('LandlordId not provided test', async ({ page }) => {
-  await page.goto('http://localhost:3000/profiles');
-  await expect(page.getByRole('main')).toContainText('Profile Page');
+  test('Landlord does not exist: no user with ID', async ({ page }) => {
+    await page.goto('http://localhost:3000/profile/123');
+    await expect(page.locator('h2')).toContainText('This page could not be found.');
+  });
+
+  test('LandlordId not provided test', async ({ page }) => {
+    await page.goto('http://localhost:3000/profiles');
+    await expect(page.getByRole('main')).toContainText('Profile Page');
+  });
 });


### PR DESCRIPTION
In an attempt to make it easier to update tests to use different users if needed in the future, updates the existing tests to use an updated users helper list for user-specific values.

This should make it so that minimal changes are needed (potentially only changing a single number) to update tests to use a different user if conflicts arise with different tests wanting to use the same users.