### PR TITLE
merge `development` and `production` branches into `main`

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,10 +11,10 @@ name: ESLint
 
 on:
   push:
-    branches: [ "development" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "development" ]
+    branches: [ "main" ]
   schedule:
     - cron: '24 21 * * 5'
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,7 +4,7 @@ name: Deploy Migrations to Production
 on:
   push:
     branches:
-      - production
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
To speed up delivery of updates in the final stages of development now that we are confident in our branch protection, will remove the separate production branch & rename `development` to main.

This PR adjusts the GitHub Actions for these branches to use the new name
